### PR TITLE
Fix bug with watching scss files

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "mocha",
     "build-scss": "node-sass --output media/css media/scss/main.scss --output-style compressed --source-map true",
-    "watch-scss": "nodemon -e media/scss -x 'npm run build-scss'"
+    "watch-scss": "nodemon -e scss -x 'npm run build-scss'"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "mocha",
     "build-scss": "node-sass --output media/css media/scss/main.scss --output-style compressed --source-map true",
-    "watch-scss": "nodemon -e scss -x 'npm run build-scss'"
+    "watch-scss": "nodemon --watch media/scss --verbose -e scss -x 'npm run build-scss'"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Nodemon uses '-e' to denote that it will watch a specified file
extension. I mistakenly thought it referred to a directory, so I
switched it back.