### PR TITLE
Used pluralize templatetag instead of conditionals for pluralizing Partner header

### DIFF
--- a/portfolio/templates/main/entry.html
+++ b/portfolio/templates/main/entry.html
@@ -68,11 +68,7 @@
                 {% with partners=page.partners.all %}
                     {% if partners %}
                     <dt class="field-label">
-                    {% if partners.count > 1 %}
-                    Partners
-                    {% else %}
-                    Partner
-                    {% endif %}
+                    Partner{{ partners|pluralize }}
                     </dt>
                     <dd>
                         {% for partner in partners %}


### PR DESCRIPTION
As @nikolas suggested. I'm using the handy `pluralize` templatetag