### PR TITLE
travis: test on python 3.5 and 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
-  - "3.4"
+  - "3.5"
+  - "3.6"
 install:
   - pip install -U pip wheel
   - pip install -U setuptools


### PR DESCRIPTION
Currently, portfolio-prod is on python 3.5, while jenkins is on 3.6.