### PR TITLE
Update django-s3sign --> v0.3.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -105,7 +105,7 @@ django-cogwheels==0.3
 webencodings==0.5.1 # needed for wagtail
 urllib3==1.26.7 # wagtail elasticsearch backend
 
-django-s3sign<=0.2.1
+django-s3sign<=0.3.2
 django-cacheds3storage==0.2.2
 ccnmtlsettings==1.9.0
 text_unidecode==1.3


### PR DESCRIPTION
Seems to run as well as the previous version.